### PR TITLE
코인 타입으로 구분하도록 개선

### DIFF
--- a/src/main/kotlin/com/playcoin/playwalletservicefees/api/controller/FeeController.kt
+++ b/src/main/kotlin/com/playcoin/playwalletservicefees/api/controller/FeeController.kt
@@ -1,27 +1,21 @@
 package com.playcoin.playwalletservicefees.api.controller
 
-import com.playcoin.playwalletservicefees.api.client.bitcoin.BitcoinFeesClient
-import com.playcoin.playwalletservicefees.api.client.bitcoin.BitcoinFeesRes
-import com.playcoin.playwalletservicefees.api.domain.Fee
 import com.playcoin.playwalletservicefees.api.domain.FeeResponse
+import com.playcoin.playwalletservicefees.api.service.FeeService
+import com.playcoin.playwalletservicefees.enums.CoinType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
-import java.lang.RuntimeException
-import java.math.BigDecimal
 
 @RestController
-@RequestMapping("/fees")
 class FeeController {
 
     @Autowired
-    lateinit var bitcoinFeesClient: BitcoinFeesClient
+    lateinit var feeService: FeeService
 
-    @GetMapping
-    fun fees(): FeeResponse = FeeResponse.fromResult(bitcoinFees())
+    @GetMapping("/{coinType}/fees")
+    fun btcFees(@PathVariable coinType: CoinType): FeeResponse
+        = FeeResponse.fromResult(feeService.fees(coinType = coinType))
 
-    fun bitcoinFees(): Result<Fee> = bitcoinFeesClient.fees().runCatching {
-        Fee(slow = this.hourFee, normal = this.halfHourFee, fast = this.fastestFee)
-    }
 }

--- a/src/main/kotlin/com/playcoin/playwalletservicefees/api/service/FeeService.kt
+++ b/src/main/kotlin/com/playcoin/playwalletservicefees/api/service/FeeService.kt
@@ -1,7 +1,8 @@
 package com.playcoin.playwalletservicefees.api.service
 
 import com.playcoin.playwalletservicefees.api.domain.Fee
+import com.playcoin.playwalletservicefees.enums.CoinType
 
 interface FeeService {
-    fun fees(): Result<Fee>
+    fun fees(coinType: CoinType): Result<Fee>
 }

--- a/src/main/kotlin/com/playcoin/playwalletservicefees/api/service/impl/FeeServiceImpl.kt
+++ b/src/main/kotlin/com/playcoin/playwalletservicefees/api/service/impl/FeeServiceImpl.kt
@@ -28,10 +28,4 @@ class FeeServiceImpl: FeeService {
         Fee(slow = this.hourFee, normal = this.halfHourFee, fast = this.fastestFee)
     }
 
-//    override fun ethFees(): Result<Fee> = Result.failure(RuntimeException("Not implementation: ETH Fees"))
-//
-//    override fun plyFees(): Result<Fee> = Result.failure(RuntimeException("Not implementation: PLY Fees"))
-//
-//    override fun plxFees(): Result<Fee> = Result.failure(RuntimeException("Not implementation: PLX Fees"))
-
 }

--- a/src/main/kotlin/com/playcoin/playwalletservicefees/api/service/impl/FeeServiceImpl.kt
+++ b/src/main/kotlin/com/playcoin/playwalletservicefees/api/service/impl/FeeServiceImpl.kt
@@ -1,12 +1,37 @@
 package com.playcoin.playwalletservicefees.api.service.impl
 
+import com.playcoin.playwalletservicefees.api.client.bitcoin.BitcoinFeesClient
 import com.playcoin.playwalletservicefees.api.domain.Fee
 import com.playcoin.playwalletservicefees.api.service.FeeService
+import com.playcoin.playwalletservicefees.enums.CoinType
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.lang.RuntimeException
 
 @Service
 class FeeServiceImpl: FeeService {
 
-    override fun fees(): Result<Fee> = Result.failure(RuntimeException())
+    @Autowired
+    lateinit var bitcoinFeesClient: BitcoinFeesClient
+
+    override fun fees(coinType: CoinType): Result<Fee> = kotlin.run {
+        when(coinType) {
+            CoinType.BTC -> bitcoinFees()
+            CoinType.ETH -> Result.failure(RuntimeException("Not implementation: ETH Fees"))
+            CoinType.PLY -> Result.failure(RuntimeException("Not implementation: PLY Fees"))
+            CoinType.PLX -> Result.failure(RuntimeException("Not implementation: PLX Fees"))
+            CoinType.DMY -> Result.failure(RuntimeException("Not implementation: DMY Fees"))
+        }
+    }
+
+    fun bitcoinFees(): Result<Fee> = bitcoinFeesClient.fees().runCatching {
+        Fee(slow = this.hourFee, normal = this.halfHourFee, fast = this.fastestFee)
+    }
+
+//    override fun ethFees(): Result<Fee> = Result.failure(RuntimeException("Not implementation: ETH Fees"))
+//
+//    override fun plyFees(): Result<Fee> = Result.failure(RuntimeException("Not implementation: PLY Fees"))
+//
+//    override fun plxFees(): Result<Fee> = Result.failure(RuntimeException("Not implementation: PLX Fees"))
 
 }

--- a/src/main/kotlin/com/playcoin/playwalletservicefees/enums/CoinType.kt
+++ b/src/main/kotlin/com/playcoin/playwalletservicefees/enums/CoinType.kt
@@ -1,0 +1,9 @@
+package com.playcoin.playwalletservicefees.enums
+
+enum class CoinType(val coinName: String) {
+    BTC("BITCOIN"),
+    ETH("ETHEREUM"),
+    PLY("PLAYCOIN"),
+    PLX("PLAYCOINX"),
+    DMY("DUMMY");
+}

--- a/src/test/kotlin/com/playcoin/playwalletservicefees/api/controller/FeeControllerTest.kt
+++ b/src/test/kotlin/com/playcoin/playwalletservicefees/api/controller/FeeControllerTest.kt
@@ -25,10 +25,9 @@ class FeeControllerTest {
     val gson: Gson = GsonBuilder().create()
 
     @Test
-    fun fees() {
-
+    fun bitcoinFees() {
         val mvcResult = mockMvc
-            .perform(get("/fees").accept(MediaType.APPLICATION_JSON))
+            .perform(get("/BTC/fees").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk)
             .andReturn()
 
@@ -38,5 +37,65 @@ class FeeControllerTest {
 
         assertThat(apiResult.data).isNotNull
         assertThat(apiResult.status).isEqualTo(ResponseStatus.OK.code)
+    }
+
+    @Test
+    fun ethereumFees() {
+        val mvcResult = mockMvc
+            .perform(get("/ETH/fees").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val type = object : TypeToken<ApiResponse<Fee>>() {}.type
+        val content = mvcResult.response.contentAsString
+        val apiResult = gson.fromJson<ApiResponse<Fee>>(content, type)
+
+        assertThat(apiResult.data).isNull()
+        assertThat(apiResult.status).isEqualTo(ResponseStatus.ERROR.code)
+    }
+
+    @Test
+    fun playcoinFees() {
+        val mvcResult = mockMvc
+            .perform(get("/PLY/fees").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val type = object : TypeToken<ApiResponse<Fee>>() {}.type
+        val content = mvcResult.response.contentAsString
+        val apiResult = gson.fromJson<ApiResponse<Fee>>(content, type)
+
+        assertThat(apiResult.data).isNull()
+        assertThat(apiResult.status).isEqualTo(ResponseStatus.ERROR.code)
+    }
+
+    @Test
+    fun playcoinxFees() {
+        val mvcResult = mockMvc
+            .perform(get("/PLX/fees").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val type = object : TypeToken<ApiResponse<Fee>>() {}.type
+        val content = mvcResult.response.contentAsString
+        val apiResult = gson.fromJson<ApiResponse<Fee>>(content, type)
+
+        assertThat(apiResult.data).isNull()
+        assertThat(apiResult.status).isEqualTo(ResponseStatus.ERROR.code)
+    }
+
+    @Test
+    fun dummyFees() {
+        val mvcResult = mockMvc
+            .perform(get("/DMY/fees").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val type = object : TypeToken<ApiResponse<Fee>>() {}.type
+        val content = mvcResult.response.contentAsString
+        val apiResult = gson.fromJson<ApiResponse<Fee>>(content, type)
+
+        assertThat(apiResult.data).isNull()
+        assertThat(apiResult.status).isEqualTo(ResponseStatus.ERROR.code)
     }
 }

--- a/src/test/kotlin/com/playcoin/playwalletservicefees/api/controller/FeeControllerTest.kt
+++ b/src/test/kotlin/com/playcoin/playwalletservicefees/api/controller/FeeControllerTest.kt
@@ -98,4 +98,11 @@ class FeeControllerTest {
         assertThat(apiResult.data).isNull()
         assertThat(apiResult.status).isEqualTo(ResponseStatus.ERROR.code)
     }
+
+    @Test
+    fun anythingFees() {
+        mockMvc
+            .perform(get("/XRP/fees").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is4xxClientError)
+    }
 }

--- a/src/test/kotlin/com/playcoin/playwalletservicefees/api/service/FeeServiceImplTest.kt
+++ b/src/test/kotlin/com/playcoin/playwalletservicefees/api/service/FeeServiceImplTest.kt
@@ -1,5 +1,6 @@
 package com.playcoin.playwalletservicefees.api.service
 
+import com.playcoin.playwalletservicefees.enums.CoinType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -17,8 +18,47 @@ class FeeServiceImplTest {
     }
 
     @Test
-    fun empty() {
-        val fee = feeService.fees()
-        assertThat(fee.isSuccess).isTrue()
+    fun bitcoinFees() {
+        val result = feeService.fees(coinType = CoinType.BTC)
+        assertThat(result.isSuccess).isTrue()
+
+        val fee = result.getOrNull()
+        assertThat(fee).isNotNull
+    }
+
+    @Test
+    fun ethereumFees() {
+        val result = feeService.fees(coinType = CoinType.ETH)
+        assertThat(result.isFailure).isTrue()
+
+        val fee = result.getOrNull()
+        assertThat(fee).isNull()
+    }
+
+    @Test
+    fun playcoinFees() {
+        val result = feeService.fees(coinType = CoinType.PLY)
+        assertThat(result.isFailure).isTrue()
+
+        val fee = result.getOrNull()
+        assertThat(fee).isNull()
+    }
+
+    @Test
+    fun playcoinxFees() {
+        val result = feeService.fees(coinType = CoinType.PLX)
+        assertThat(result.isFailure).isTrue()
+
+        val fee = result.getOrNull()
+        assertThat(fee).isNull()
+    }
+
+    @Test
+    fun dummyFees() {
+        val result = feeService.fees(coinType = CoinType.DMY)
+        assertThat(result.isFailure).isTrue()
+
+        val fee = result.getOrNull()
+        assertThat(fee).isNull()
     }
 }


### PR DESCRIPTION
- enum CoinType 추가
- FeeController에서 CoinType으로 구분하도록 변경
- FeeService에서 CoinType으로 구분해서 수수료 가져오도록 변경
- BTC는 정상
- ETH, PLY, PLX 미구현
- DMY(dummy)는 비정상 요청